### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/1](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `build` job (or at the workflow root) to explicitly set the minimum required permissions. Since the `build` job only needs to check out code and does not need to write to the repository or access other privileged scopes, the minimal permission required is `contents: read`. This should be added as a new key under the `build` job, at the same indentation level as `runs-on`. No other changes are needed, and this will not affect the existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
