### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/Cyber Fraud Detection Bot.html
+++ b/Cyber Fraud Detection Bot.html
@@ -407,6 +407,21 @@
         });
 
         // --- IOC Management Logic ---
+
+        // Helper function to escape HTML special characters
+        function escapeHTML(str) {
+            return str.replace(/[&<>"']/g, function (m) {
+                switch (m) {
+                    case '&': return '&amp;';
+                    case '<': return '&lt;';
+                    case '>': return '&gt;';
+                    case '"': return '&quot;';
+                    case "'": return '&#39;';
+                    default: return m;
+                }
+            });
+        }
+
         document.getElementById('showAssociationsBtn').addEventListener('click', () => {
             const primaryInput = document.getElementById('iocInput').value.trim();
             const iocCardsContainer = document.getElementById('iocCardsContainer');
@@ -529,7 +544,7 @@
 
                 if (domainAssociationsList && domainAssociationsPlaceholder) {
                     if (mockAssociations.length > 0) {
-                        domainAssociationsList.innerHTML = mockAssociations.map(assoc => `<li>${assoc}</li>`).join('');
+                        domainAssociationsList.innerHTML = mockAssociations.map(assoc => `<li>${escapeHTML(assoc)}</li>`).join('');
                         domainAssociationsList.classList.remove('hidden'); // Show the list
                         domainAssociationsPlaceholder.classList.add('hidden'); // Hide the placeholder
                     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/3](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/3)

To fix this vulnerability, we must ensure that any user-controlled data inserted into the DOM as HTML is properly escaped, so that special HTML characters (like `<`, `>`, `&`, `"`, `'`) are not interpreted as HTML or JavaScript. The best way to do this is to escape the user input before inserting it into the DOM. In this case, we should escape each `assoc` value before wrapping it in `<li>...</li>`. This can be done by creating a helper function (e.g., `escapeHTML`) that replaces special characters with their HTML entity equivalents. We should define this function in the script and use it when mapping `mockAssociations` to list items.

**What to change:**
- Add an `escapeHTML` function in the script section.
- Change the mapping in line 532 to use `escapeHTML(assoc)` instead of just `assoc`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
