### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/Cyber Fraud Detection Bot.html
+++ b/Cyber Fraud Detection Bot.html
@@ -536,7 +536,7 @@
                     } else {
                         iocCardsContainer.innerHTML = `
                             <div class="col-span-full text-center text-gray-400" id="iocPlaceholder">
-                                No IOCs found for "${primaryInput}".
+                                No IOCs found for "${escapeHTML(primaryInput)}".
                             </div>
                         `;
                     }


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/2](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/2)

To fix the vulnerability, we must ensure that any user input (`primaryInput`) is properly escaped before being inserted into the DOM as HTML. The best way to do this is to use the existing `escapeHTML` function to sanitize `primaryInput` in the template literal on line 539. Specifically, in the block where no IOCs are found, change:

```js
539: No IOCs found for "${primaryInput}".
```

to

```js
539: No IOCs found for "${escapeHTML(primaryInput)}".
```

This change should be made in the template literal assigned to `iocCardsContainer.innerHTML` on line 537. No other changes are required, as the escaping function is already defined and used elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
