### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/dietician-bot.html
+++ b/dietician-bot.html
@@ -218,11 +218,23 @@
     window.location.href = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
   }
 
+  function escapeHtml(text) {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+      '`': '&#96;',
+    };
+    return String(text).replace(/[&<>"'`]/g, function(m) { return map[m]; });
+  }
+
   function printContent(id){
     const el = document.getElementById(id);
     const content = el.value || el.textContent;
     const w = window.open();
-    w.document.write('<pre style="font-family: monospace; white-space: pre-wrap; font-size: 16px;">' + content + '</pre>');
+    w.document.write('<pre style="font-family: monospace; white-space: pre-wrap; font-size: 16px;">' + escapeHtml(content) + '</pre>');
     w.document.close();
     w.focus();
     w.print();


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/6](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/6)

To fix the problem where untrusted text is injected into HTML without escaping, you should encode special HTML characters before injecting the content into the HTML of a new document. Specifically, prior to concatenating `content` into the HTML written by `document.write`, the string must be escaped so that `<`, `>`, `&`, `"`, and `'` are replaced with their corresponding HTML entities. This ensures that user-supplied text cannot be interpreted as HTML or JavaScript.

Modify the `printContent` function in `dietician-bot.html` to escape/encode `content` using a dedicated function for HTML escaping before it is inserted into the string written to the document. The best way is to implement a helper function such as `escapeHtml` and pass `content` through it.

All changes should be confined to the JavaScript in `dietician-bot.html`, specifically within the region of the `printContent` function. You will need to:
1. Add a helper function that escapes HTML entities.
2. Use this function when writing `content` to the new document.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
