### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/music.html
+++ b/music.html
@@ -476,6 +476,19 @@
   let onlineSongs = [],
       offlineFiles = [],
       playlist = JSON.parse(localStorage.getItem("playlist") || "[]");
+
+  function escapeHTML(str) {
+    return String(str).replace(/[&<>'"`]/g, function (m) {
+      return ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#39;',
+        '"': '&quot;',
+        '`': '&#96;'
+      })[m];
+    });
+  }
   let isSignup = false;
 
   function disableTabs(disabled = true) {
@@ -689,10 +702,10 @@
       li.className = "songItem";
       const url = URL.createObjectURL(file);
       li.innerHTML = `
-        <div class="title" title="${file.name}" style="max-width:100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${file.name}</div>
-        <audio controls preload="none" src="${url}" aria-label="Play offline song ${file.name}"></audio>
+        <div class="title" title="${escapeHTML(file.name)}" style="max-width:100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${escapeHTML(file.name)}</div>
+        <audio controls preload="none" src="${url}" aria-label="Play offline song ${escapeHTML(file.name)}"></audio>
         <div class="actions">
-          <button class="btnAction btnDelete" aria-label="Delete offline song ${file.name}">Delete</button>
+          <button class="btnAction btnDelete" aria-label="Delete offline song ${escapeHTML(file.name)}">Delete</button>
         </div>
       `;
       li.querySelector(".btnDelete").addEventListener("click", () => {


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/7](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/7)

To prevent XSS, we must ensure that any user-controlled data, such as `file.name`, is properly escaped before it is injected into HTML via `innerHTML`. The preferred way is to avoid using `innerHTML` for dynamic content, instead using safer DOM APIs like `textContent` for raw text, or constructing the element tree manually. However, if `innerHTML` must be used (such as in the provided code for rapid markup generation), **properly escape** any interpolated values.

For this fix:
- Create an `escapeHTML` function to encode HTML meta-characters (`&`, `<`, `>`, `"`, `'`, and `` ` ``) before inserting data into HTML.
- Apply this function to all interpolated instances of `file.name` in the `li.innerHTML` assignment in `renderOfflineFiles`.
- Replace `${file.name}` with `${escapeHTML(file.name)}` everywhere in the template literal in line 691.
- Place the `escapeHTML` function within the script context so it's available to `renderOfflineFiles`.

No changes to existing functionality are necessary; only the display of filenames will be HTML-escaped for security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
