### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/Cyber Fraud Detection Bot.html
+++ b/Cyber Fraud Detection Bot.html
@@ -219,6 +219,16 @@
   <footer class="bg-gray-800 py-5 text-center text-gray-400"><small>© 2025 CyberGuard AI. All rights reserved.</small></footer>
 
   <script>
+    // Escapes HTML meta-characters to prevent XSS
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/`/g, '&#96;');
+    }
     // Tab nav
     const tabs = document.querySelectorAll('.tab-link');
     const contents = document.querySelectorAll('.tab-content');
@@ -436,8 +446,8 @@
         const keywords = ['redirect','bounce','cloak','hidden','proxy','difference'];
         const found = keywords.some(k => val.includes(k));
         out.innerHTML = found
-          ? `<p>Warning: Cloaking detected for <code>${val}</code>.</p>`
-          : `<p>No cloaking detected for <code>${val}</code>.</p>`;
+          ? `<p>Warning: Cloaking detected for <code>${escapeHTML(val)}</code>.</p>`
+          : `<p>No cloaking detected for <code>${escapeHTML(val)}</code>.</p>`;
       });
     });
   </script>


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/20](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/20)

The vulnerability arises from directly including user-controlled input (`val`) in an HTML template literal assigned to `innerHTML`. The fix is to escape all HTML meta-characters in the user input before including it in HTML output. The best-practice fix is to use a dedicated function to encode special HTML characters in `val` (like `&`, `<`, `>`, `"`, `'`, and `` ` ``) before putting them in an HTML context.

Thus:  
- Implement an `escapeHTML` function in your `<script>` block.  
- Before inserting `val` into any HTML template string, pass it through this function (e.g., `escapeHTML(val)`).  
- Apply this fix everywhere in the file where untrusted user input is used in `innerHTML`.

For this specific file, the following lines must be fixed:
- On line 439 and 440, change `<code>${val}</code>` to `<code>${escapeHTML(val)}</code>`.

Add the `escapeHTML` function definition above its first use in the script tag.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
