### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/Cyber Fraud Detection Bot.html
+++ b/Cyber Fraud Detection Bot.html
@@ -320,6 +320,16 @@
       out.innerHTML = `<p>Processed ${list.length} IOCs:</p><ul>${list.map(i => `<li>${i}</li>`).join('')}</ul>`;
     });
 
+    // Utility function to escape user-provided text for HTML
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     // Similarity Scan
     document.getElementById('similarityScanBtn').addEventListener('click', async () => {
       const val = document.getElementById('similarityInput').value.trim();
@@ -356,7 +366,7 @@
       if(!files || files.length === 0) return out.innerHTML = '<p class="text-red-400">Select files to process.</p>';
       out.innerHTML = '<div class="spinner"></div>';
       await simulateAsync(() => {
-        out.innerHTML = `<ul>${Array.from(files).map(f => `<li>${f.name}</li>`).join('')}</ul>`;
+        out.innerHTML = `<ul>${Array.from(files).map(f => `<li>${escapeHTML(f.name)}</li>`).join('')}</ul>`;
       });
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/14](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/14)

To fix the problem, we should ensure that any untrusted text interpolated into the HTML is safely escaped for HTML meta-characters. The file names in the list (`f.name`) should be properly escaped before including them in the HTML string constructed for display. The most robust and backward-compatible method in vanilla JS is to define a small escape function which encodes dangerous HTML characters (`<`, `>`, `&`, `"`, `'`) into their respective entities. This can be easily accomplished with a utility function such as `escapeHTML(str)`. 

Applied specifically:
- In the event listener for `'filesScanBtn'`, replace the direct string interpolation of `f.name` with `escapeHTML(f.name)`.
- Insert the `escapeHTML` function in an appropriate location, such as within the same `<script>` context but above the event listeners.

No external dependencies are required; a simple utility suffices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
