### PR TITLE
Potential fix for code scanning alert no. 19: DOM text reinterpreted as HTML

### DIFF
--- a/Cyber Fraud Detection Bot.html
+++ b/Cyber Fraud Detection Bot.html
@@ -219,6 +219,21 @@
   <footer class="bg-gray-800 py-5 text-center text-gray-400"><small>© 2025 CyberGuard AI. All rights reserved.</small></footer>
 
   <script>
+    // Escapes HTML special chars in a string for safe insertion into innerHTML
+    function escapeHTML(str) {
+      return str.replace(/[&<>"'`=\/]/g, function(s) {
+        return ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;',
+          '`': '&#96;',
+          '=': '&#61;',
+          '/': '&#47;'
+        })[s];
+      });
+    }
     // Escapes HTML meta-characters to prevent XSS
     function escapeHTML(str) {
       return String(str)
@@ -441,8 +456,8 @@
         const keywords = ['phishing','pretext','baiting','scareware','spoof','email fraud'];
         const found = keywords.some(k => val.includes(k));
         out.innerHTML = found
-          ? `<p>Warning: <code>${val}</code> shows social engineering signs.</p>`
-          : `<p>No social engineering signs for <code>${val}</code>.</p>`;
+          ? `<p>Warning: <code>${escapeHTML(val)}</code> shows social engineering signs.</p>`
+          : `<p>No social engineering signs for <code>${escapeHTML(val)}</code>.</p>`;
       });
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/19](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/19)

To eliminate the vulnerability, any user input (`val`) that is injected via template literals directly into HTML (using `innerHTML`) should be properly escaped to render it as plain text (not markup). This is best accomplished by passing `val` through an escaping function such as `escapeHTML(val)`, which replaces `<`, `>`, `&`, `"` and `'` with their respective HTML entities.

**Steps:**
- Identify all occurrences where unescaped `val` is injected into HTML within the vulnerable handler (`socialScanBtn` click event).
- Replace these with `escapeHTML(val)`.
- Ensure that `escapeHTML` is defined in the snippet (if not already present in the context shown).

**Files/regions/lines to change:**  
- Cyber Fraud Detection Bot.html: Inside `<script>`, particularly inside the social engineering analysis block (lines around 443–445).

**Requirements:**
- A robust `escapeHTML` function must exist in the script before it's called.
- Replace all `${val}` usages inside HTML-injecting statements in this block with `${escapeHTML(val)}`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
