### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/Cyber Fraud Detection Bot.html
+++ b/Cyber Fraud Detection Bot.html
@@ -332,7 +332,7 @@
       const out = document.getElementById('iocResults');
       if(!val) return out.innerHTML = '<p class="text-red-400">Enter IOC data.</p>';
       const list = val.split(/[\n,]+/).map(i => i.trim()).filter(Boolean);
-      out.innerHTML = `<p>Processed ${list.length} IOCs:</p><ul>${list.map(i => `<li>${i}</li>`).join('')}</ul>`;
+      out.innerHTML = `<p>Processed ${list.length} IOCs:</p><ul>${list.map(i => `<li>${escapeHTML(i)}</li>`).join('')}</ul>`;
     });
 
     // Utility function to escape user-provided text for HTML


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/13](https://github.com/MOHAMMAD3230/PROJECT/security/code-scanning/13)

The best approach to fix this issue is to escape user-controlled data before inserting it into the DOM as HTML. Rather than interpolating `${i}` directly in `<li>${i}</li>`, we should apply the `escapeHTML` function, i.e. `<li>${escapeHTML(i)}</li>`, to ensure any special HTML characters are converted to their safe representations. This prevents any attempt to break out of the list item with injected tags or scripts, eliminating the XSS risk. We only modify the code constructing the HTML output for the IOCs list in the relevant event handler, leaving all other logic and behavior unchanged.

This fix requires no new methods or imports, as the `escapeHTML` function is already defined elsewhere in the snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
